### PR TITLE
Back-port secure request fix

### DIFF
--- a/embedly/client.py
+++ b/embedly/client.py
@@ -52,7 +52,7 @@ class Embedly(object):
         if self.services:
             return self.services
 
-        url = 'http://api.embed.ly/1/services/python'
+        url = 'https://api.embed.ly/1/services/python'
 
         http = httplib2.Http(timeout=self.timeout)
         headers = {'User-Agent': self.user_agent,
@@ -122,7 +122,7 @@ class Embedly(object):
         else:
             query += '&url=%s' % quote(url_or_urls)
 
-        url = 'http://api.embed.ly/%s/%s?%s' % (version, method, query)
+        url = 'https://api.embed.ly/%s/%s?%s' % (version, method, query)
 
         http = httplib2.Http(timeout=self.timeout)
 


### PR DESCRIPTION
Thanks for maintaining this fork.

This package makes insecure requests to the Embedly API. This is fixed upstream but of course not released (https://github.com/embedly/embedly-python/pull/28). This changeset back-ports the upstream patch.

I believe that this patch is within the spirit of the fork because it plugs a security a hole. Please feel free to close this if you disagree.